### PR TITLE
Add Auto.dev

### DIFF
--- a/collection/auto-dev.yaml
+++ b/collection/auto-dev.yaml
@@ -1,0 +1,11 @@
+name: Auto.dev
+slug: auto-dev
+description: Automotive data APIs — VIN decode, vehicle listings, payments, recalls, and specs. 1,000 free API requests per month.
+categories:
+  - Vehicles
+type: REST
+is_free: false
+auth_type: api_key
+links:
+  - name: Docs / Website
+    url: https://docs.auto.dev/v2/cli-mcp-sdk


### PR DESCRIPTION
Add Auto.dev to the Vehicles category.

**Auto.dev** — Automotive data APIs with VIN decode, vehicle listings, payments, recalls, and specs. 1,000 free API requests per month.

- Docs: https://docs.auto.dev/v2/cli-mcp-sdk
- GitHub: https://github.com/drivly/auto-dev-skill