### PR TITLE
Add AgentDeals API

### DIFF
--- a/collection/agentdeals.yaml
+++ b/collection/agentdeals.yaml
@@ -1,0 +1,14 @@
+name: AgentDeals
+slug: agentdeals
+description: Search and compare 1,600+ developer infrastructure deals — free tiers, startup credits, and pricing changes across 54 categories. REST API and MCP server for AI agents.
+categories:
+  - Business
+type: REST
+is_free: true
+links:
+  - name: Docs / Website
+    url: https://agentdeals.dev/developers
+  - name: API Reference
+    url: https://agentdeals.dev/api/docs
+  - name: GitHub
+    url: https://github.com/robhunter/agentdeals


### PR DESCRIPTION
## Summary

Add AgentDeals — a free REST API for developer tool pricing intelligence.

- **1,600+ offers** across 54 categories (free tiers, startup credits, pricing changes)
- **17 REST API endpoints** — search, compare vendors, plan stacks, track pricing changes
- **Free, no auth required**
- Docs: https://agentdeals.dev/api/docs
- Developer hub: https://agentdeals.dev/developers
- GitHub: https://github.com/robhunter/agentdeals

Category: Business (covers developer infrastructure pricing data)