### PR TITLE
Add AI Dev Jobs and Not Human Search APIs

### DIFF
--- a/collection/ai-dev-jobs.yaml
+++ b/collection/ai-dev-jobs.yaml
@@ -1,0 +1,22 @@
+name: AI Dev Jobs
+slug: ai-dev-jobs
+description: REST API for 8,400+ active AI/ML engineering jobs from 580 company ATS sources (Anthropic, OpenAI, Meta FAIR, Google DeepMind, Scale, Cohere, and 475+ more). Search by role, tags, location, workplace (remote/hybrid/onsite), experience level, and salary range. Also exposes an MCP server for AI agents.
+categories:
+  - Jobs
+  - AI & ML
+type: REST
+is_free: true
+specification:
+  type: openapi
+  url: https://aidevboard.com/openapi.yaml
+links:
+  - name: Docs / Website
+    url: https://aidevboard.com/docs
+  - name: API endpoint
+    url: https://aidevboard.com/api/v1/jobs
+  - name: MCP server
+    url: https://aidevboard.com/mcp
+  - name: RSS feed
+    url: https://aidevboard.com/feed.xml
+  - name: OpenAPI spec
+    url: https://aidevboard.com/openapi.yaml

--- a/collection/not-human-search.yaml
+++ b/collection/not-human-search.yaml
@@ -1,0 +1,20 @@
+name: Not Human Search
+slug: not-human-search
+description: Agent-first search engine. Indexes 8,000+ AI tools, MCP servers, and agent-readable services, ranked across 7 agentic readiness signals (llms.txt, OpenAPI, ai-plugin, MCP, structured API, robots.txt, schema.org). Queryable via REST API, MCP server, or browser. Includes a verify_mcp tool that does a live JSON-RPC probe of any MCP URL.
+categories:
+  - Search
+  - AI & ML
+type: REST
+is_free: true
+specification:
+  type: openapi
+  url: https://nothumansearch.ai/openapi.yaml
+links:
+  - name: Docs / Website
+    url: https://nothumansearch.ai
+  - name: API endpoint
+    url: https://nothumansearch.ai/api/v1/search
+  - name: MCP server
+    url: https://nothumansearch.ai/mcp
+  - name: llms.txt
+    url: https://nothumansearch.ai/llms.txt


### PR DESCRIPTION
Two free public APIs, both also exposing MCP servers for AI agents:

**AI Dev Jobs** (`ai-dev-jobs.yaml`)
- REST API for 8,400+ active AI/ML engineering jobs
- Categories: Jobs, AI & ML
- OpenAPI spec: https://aidevboard.com/openapi.yaml
- Free, no auth for read operations

**Not Human Search** (`not-human-search.yaml`)
- Agent-first search engine indexing 8,000+ AI tools and MCP servers
- Categories: Search, AI & ML
- OpenAPI spec: https://nothumansearch.ai/openapi.yaml
- Free, no auth

Both follow the required schema (name, slug, categories, type, is_free, specification, links) and include OpenAPI specs for machine-readability. I did not run `npm run build` — happy to run it and add the generated README/dist diff if preferred (left it to maintainers to avoid merge conflicts on generated files).